### PR TITLE
chore: add CODEOWNERS entry for .github/agents folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,12 @@
 # CODEOWNERS documentation : https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners
 
 # add here at least the following to control the approval process of new changes to the repo 
-# * @Contentsquare/<your unit name in Github>
+* @Contentsquare/ios
 
 # add lower granularity approval requirements here if there's a need for other stakeholders to approve changes to specific files
 
 # helmfile.yaml should be the same on every repo and is centrally managed by PF team
 helmfile.yaml @ContentSquare/devx
+
+# Protect .github/agents folder for GitHub Copilot agents
+/.github/agents/ @Contentsquare/ios


### PR DESCRIPTION
## Description
Add a CODEOWNERS entry to protect the `.github/agents/` folder

## Motivation and Context
Proactively protect the GitHub agents folder so that when GitHub Copilot agent configurations are added, they will require review from the repository owners.

## Breaking Changes
No

## How Has This Been Tested?
N/A - CODEOWNERS configuration change only